### PR TITLE
Didn't work with PHP7. Enabled the remi-php70 repository to fix that.

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,4 +1,4 @@
 ---
 - name: Ensure PHPMyAdmin is installed.
-  yum: name=phpmyadmin state=installed enablerepo=epel
+  yum: name=phpmyadmin state=installed enablerepo=epel,remi-70
   notify: restart apache

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,4 +1,4 @@
 ---
 - name: Ensure PHPMyAdmin is installed.
-  yum: name=phpmyadmin state=installed enablerepo=epel,remi-70
+  yum: name=phpmyadmin state=installed enablerepo=epel,remi-php70
   notify: restart apache


### PR DESCRIPTION
The role didn't install when you were using PHP7 from the remi-php70 repository. This was due to a misschien 'enable-repo'.
