### PR TITLE
Customized config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ phpMyAdmin is a simple interface for interacting with MySQL databases via a web 
 
     phpmyadmin_config_file: /etc/phpmyadmin/config.inc.php
 
-The path to the phpMyAdmin config file.
+The path to the phpMyAdmin config file. Platform specific values are defined in role vars directory.
+
+    phpmyadmin_use_default_config: true
+
+Whether to use the included default phpMyAdmin config file, defined with the following variables. Set this to `false` and copy your own `config.inc.php` file into the `phpmyadmin_config_path` if you'd like to use a more complicated setup. If this variable is set to `true`, all other configuration will be taken from phpMyAdmin's own [default config](https://docs.phpmyadmin.net/en/latest/config.html).
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
@@ -35,6 +39,20 @@ These variables define the connection method and hostname phpMyAdmin will use to
     phpmyadmin_mysql_password: "{{ mysql_root_password }}"
 
 The username and password with which phpMyAdmin will attempt to log into the MySQL server. The `mysql_root_password` should be set as part of the `geerlingguy.mysql` role, but you can change the user and password to another account entirely, and you most defintely *should*, especially if you're connecting to a non-development database server!
+
+    phpmyadmin_apache_template_path: phpmyadmin.conf.j2
+
+Path to a template for generating an Apache proxy config file. Defaults to the template inside `templates/phpmyadmin.conf.j2`. This path should be relative to the directory from which you run your playbook.
+
+    phpmyadmin_allow_access_ip:
+      - 127.0.0.1
+      - ::1
+    phpmyadmin_allow_setup_ip:
+      - 127.0.0.1
+      - ::1
+
+These variables define the IP addresses allowed to access phpmyadmin root and setup sites defined in the Apache phpmyadmin.conf files (can use a list of values). Default values for both variables are the localhost addresses.
+
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,10 @@
 # for RHEL/CentOS.
 phpmyadmin_enablerepo: epel
 
-# set to false if custom config will be copied to host separately
+# Set this to false if you're not using phpMyAdmin with Apache/Nginx/etc.
+phpmyadmin_enable_webserver: true
+
+# set to false if custom phpmyadmin config will be copied to host separately
 phpmyadmin_use_default_config: true
 
 # Override if needed. This is set platform-specific in the vars dir if not set.
@@ -15,3 +18,15 @@ phpmyadmin_mysql_socket: ""
 phpmyadmin_mysql_connect_type: tcp
 phpmyadmin_mysql_user: root
 phpmyadmin_mysql_password: "{{ mysql_root_password }}"
+
+phpmyadmin_apache_template_path: phpmyadmin.conf.j2
+
+# Apache phpmyadmin.conf ip address access to phpmyadmin root and setup webpages
+# (can use a list of values)
+phpmyadmin_allow_access_ip:
+  - 127.0.0.1
+  - ::1
+
+phpmyadmin_allow_setup_ip:
+  - 127.0.0.1
+  - ::1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ phpmyadmin_use_default_config: true
 # Override if needed. This is set platform-specific in the vars dir if not set.
 # phpmyadmin_config_file: /etc/phpmyadmin/config.inc.php
 
+# Specific variables set in the default config.inc.php file
 phpmyadmin_mysql_host: localhost
 phpmyadmin_mysql_port: ""
 phpmyadmin_mysql_socket: ""
@@ -19,10 +20,12 @@ phpmyadmin_mysql_connect_type: tcp
 phpmyadmin_mysql_user: root
 phpmyadmin_mysql_password: "{{ mysql_root_password }}"
 
+# Local path to Jinja2 template for generating Apache virtual server file
 phpmyadmin_apache_template_path: phpmyadmin.conf.j2
 
-# Apache phpmyadmin.conf ip address access to phpmyadmin root and setup webpages
-# (can use a list of values)
+# IP addresses allowed to access phpmyadmin root and setup sites defined in
+# Apache phpmyadmin.conf (can use a list of values).
+
 phpmyadmin_allow_access_ip:
   - 127.0.0.1
   - ::1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,9 @@
 # for RHEL/CentOS.
 phpmyadmin_enablerepo: epel
 
+# set to false if custom config will be copied to host separately
+phpmyadmin_use_default_config: true
+
 # Override if needed. This is set platform-specific in the vars dir if not set.
 # phpmyadmin_config_file: /etc/phpmyadmin/config.inc.php
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
---
+---
 - name: restart webserver
   service:
     name: "{{ phpmyadmin_webserver_daemon }}"
     state: restarted
-when: phpmyadmin_enable_webserver
+  when: phpmyadmin_enable_webserver

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,6 @@
+--
+- name: restart webserver
+  service:
+    name: "{{ phpmyadmin_webserver_daemon }}"
+    state: restarted
+when: phpmyadmin_enable_webserver

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Define phpmyadmin_webserver_daemon.
   set_fact:
-    php_webserver_daemon: "{{ __phpmyadmin_webserver_daemon }}"
+    phpmyadmin_webserver_daemon: "{{ __phpmyadmin_webserver_daemon }}"
   when: phpmyadmin_webserver_daemon is not defined
 
 # Setup/install tasks.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,3 +35,4 @@
       value: "{{ phpmyadmin_mysql_user }}"
     - key: password
       value: "{{ phpmyadmin_mysql_password }}"
+  when: phpmyadmin_use_default_config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,16 @@
     phpmyadmin_config_file: "{{ __phpmyadmin_config_file }}"
   when: phpmyadmin_config_file is not defined
 
+- name: Define phpmyadmin_apache_config_file.
+  set_fact:
+    phpmyadmin_apache_config_file: "{{ __phpmyadmin_apache_config_file }}"
+  when: phpmyadmin_apache_config_file is not defined
+
+- name: Define phpmyadmin_webserver_daemon.
+  set_fact:
+    php_webserver_daemon: "{{ __phpmyadmin_webserver_daemon }}"
+  when: phpmyadmin_webserver_daemon is not defined
+
 # Setup/install tasks.
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
@@ -36,3 +46,12 @@
     - key: password
       value: "{{ phpmyadmin_mysql_password }}"
   when: phpmyadmin_use_default_config
+
+- name: Configuring apache virtual site for phpmyadmin.
+  template:
+    src: "{{ phpmyadmin_apache_template_path }}"
+    dest: "{{ phpmyadmin_apache_config_file }}"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart webserver

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -10,4 +10,4 @@
     regexp: "^Include.+phpmyadmin.+$"
     line: "Include /etc/phpmyadmin/apache.conf"
     insertafter: "EOF"
-  notify: restart apache
+  notify: restart webserver

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,4 +1,4 @@
 ---
 - name: Ensure phpMyAdmin is installed.
   yum: name=phpmyadmin state=present enablerepo={{ phpmyadmin_enablerepo }}
-  notify: restart apache
+  notify: restart webserver

--- a/templates/phpmyadmin.conf.j2
+++ b/templates/phpmyadmin.conf.j2
@@ -1,0 +1,99 @@
+# phpMyAdmin - Web based MySQL browser written in php
+# 
+# Allows only localhost by default
+#
+# But allowing phpMyAdmin to anyone other than localhost should be considered
+# dangerous unless properly secured by SSL
+
+Alias /phpMyAdmin /usr/share/phpMyAdmin
+Alias /phpmyadmin /usr/share/phpMyAdmin
+
+<Directory /usr/share/phpMyAdmin/>
+   AddDefaultCharset UTF-8
+
+   <IfModule mod_authz_core.c>
+     # Apache 2.4
+     <RequireAny>
+{% if phpmyadmin_allow_access_ip is defined %}
+{% for require_ip, value in phpmyadmin_allow_access_ip.items() | list %}
+       Require ip "{{ value }}"
+{% endfor %}
+{% else %}
+       Require ip 127.0.0.1
+       Require ip ::1
+{% endif %}
+     </RequireAny>
+   </IfModule>
+   <IfModule !mod_authz_core.c>
+     # Apache 2.2
+     Order Deny,Allow
+     Deny from All
+{% if phpmyadmin_allow_access_ip is defined %}
+{% for allow_from, value in phpmyadmin_allow_access_ip.items() | list %}
+       Allow from "{{ value }}"
+{% endfor %}
+{% else %}
+       Allow from 127.0.0.1
+       Allow from ::1
+{% endif %}
+   </IfModule>
+</Directory>
+
+<Directory /usr/share/phpMyAdmin/setup/>
+   <IfModule mod_authz_core.c>
+     # Apache 2.4
+     <RequireAny>
+{% if phpmyadmin_allow_setup_ip is defined %}
+{% for require_ip, value in phpmyadmin_allow_setup_ip.items() | list %}
+       Require ip "{{ value }}"
+{% endfor %}
+{% else %}
+       Require ip 127.0.0.1
+       Require ip ::1
+{% endif %}
+     </RequireAny>
+   </IfModule>
+   <IfModule !mod_authz_core.c>
+     # Apache 2.2
+     Order Deny,Allow
+     Deny from All
+{% if phpmyadmin_allow_setup_ip is defined %}
+{% for allow_from, value in phpmyadmin_allow_setup_ip.items() | list %}
+       Allow from "{{ value }}"
+{% endfor %}
+{% else %}
+       Allow from 127.0.0.1
+       Allow from ::1
+{% endif %}
+   </IfModule>
+</Directory>
+
+# These directories do not require access over HTTP - taken from the original
+# phpMyAdmin upstream tarball
+#
+<Directory /usr/share/phpMyAdmin/libraries/>
+    Order Deny,Allow
+    Deny from All
+    Allow from None
+</Directory>
+
+<Directory /usr/share/phpMyAdmin/setup/lib/>
+    Order Deny,Allow
+    Deny from All
+    Allow from None
+</Directory>
+
+<Directory /usr/share/phpMyAdmin/setup/frames/>
+    Order Deny,Allow
+    Deny from All
+    Allow from None
+</Directory>
+
+# This configuration prevents mod_security at phpMyAdmin directories from
+# filtering SQL etc.  This may break your mod_security implementation.
+#
+#<IfModule mod_security.c>
+#    <Directory /usr/share/phpMyAdmin/>
+#        SecRuleInheritance Off
+#    </Directory>
+#</IfModule>

--- a/templates/phpmyadmin.conf.j2
+++ b/templates/phpmyadmin.conf.j2
@@ -15,8 +15,8 @@ Alias /phpmyadmin /usr/share/phpMyAdmin
      # Apache 2.4
      <RequireAny>
 {% if phpmyadmin_allow_access_ip is defined %}
-{% for require_ip, value in phpmyadmin_allow_access_ip.items() | list %}
-       Require ip "{{ value }}"
+{% for ip in phpmyadmin_allow_access_ip %}
+       Require ip {{ ip }}
 {% endfor %}
 {% else %}
        Require ip 127.0.0.1
@@ -29,8 +29,8 @@ Alias /phpmyadmin /usr/share/phpMyAdmin
      Order Deny,Allow
      Deny from All
 {% if phpmyadmin_allow_access_ip is defined %}
-{% for allow_from, value in phpmyadmin_allow_access_ip.items() | list %}
-       Allow from "{{ value }}"
+{% for ip in phpmyadmin_allow_access_ip %}
+       Allow from {{ ip }}
 {% endfor %}
 {% else %}
        Allow from 127.0.0.1
@@ -44,8 +44,8 @@ Alias /phpmyadmin /usr/share/phpMyAdmin
      # Apache 2.4
      <RequireAny>
 {% if phpmyadmin_allow_setup_ip is defined %}
-{% for require_ip, value in phpmyadmin_allow_setup_ip.items() | list %}
-       Require ip "{{ value }}"
+{% for ip in phpmyadmin_allow_setup_ip %}
+       Require ip {{ ip }}
 {% endfor %}
 {% else %}
        Require ip 127.0.0.1
@@ -58,8 +58,8 @@ Alias /phpmyadmin /usr/share/phpMyAdmin
      Order Deny,Allow
      Deny from All
 {% if phpmyadmin_allow_setup_ip is defined %}
-{% for allow_from, value in phpmyadmin_allow_setup_ip.items() | list %}
-       Allow from "{{ value }}"
+{% for ip in phpmyadmin_allow_setup_ip %}
+       Allow from {{ ip }}
 {% endfor %}
 {% else %}
        Allow from 127.0.0.1

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,5 @@
 ---
 __phpmyadmin_config_file: /etc/phpmyadmin/config.inc.php
+__phpmyadmin_apache_config_file: /etc/apache2/conf-available/phpmyadmin.conf
+
+__phpmyadmin_webserver_daemon: "apache2"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,2 +1,5 @@
 ---
 __phpmyadmin_config_file: /etc/phpMyAdmin/config.inc.php
+__phpmyadmin_apache_config_file: /etc/httpd/conf.d/phpMyAdmin.conf
+
+__phpmyadmin_webserver_daemon: "httpd"


### PR DESCRIPTION
Dear Jeff Geerling,
(I had some errors when attempting to rebase in last pull request. Wanted to start fresh without merge conflicts occurring. So here is a second attempt. Sorry for the issue.)

Recently read your great textbook, Ansible for DevOps. I'm currently guiding one of my college students through your textbook too, so she can also get into Ansible automation. Thank you for writing such a great, hands-on book on the subject!

I'm starting to migrate our system automation code over to Ansible in the Computer Science dept. at Wichita State University. I'm currently building a MariaDB/mySQL service on our OpenStack cloud for CS students to have easy access to a live SQL environment in their "Intro to Databases" class. Basing this new SQL service on your multi-server LAMP Infrastructure textbook example, but adding your phpMyAdmin role onto the www servers to ultimately give students a simple SQL web interface into the MariaDB server.

I found your phpMyAdmin role did not touch the default Apache config file phmyadmin.conf. So it seemed to only allow for localhost access into phpMyAdmin. To integrate it into your LAMP infrastructure, the phpMyAdmin directories needed to be accessible from the Varnish server.

I hope it is okay, but I have added to this role:

    automated configuration of the Apache phpmyadmin.conf with user definable 'require ip' and 'allow from' values using a template,
    new webserver restart handler (similar to the handler in your php role),
    new phpmyadmin_use_default_config variable check, in case user wishes to copy a more complex custom config.inc.php (this idea was borrowed from your varnish role and seemed like a good extra option), and
    additional documentation in the README.md file with details of the new variables.

This is my first pull request for an Ansible role. Please feel free to change or delete my code as you see fit. Also, I was able to test the role changes on the CentOS 7 LAMP infrastructure and everything seemed to work great. However, I do not have travis/molecule running here, so was not able to run complete tests on the code changes with different distributions.

Thank you for taking the time to review (and hopefully merge) this pull request.

Best regards,
Ben

P.S. On a separate question: within your textbook LAMP infrastructure example itself, I seem to be hitting an error with the mySQL master/slave servers not replicating correctly. I'm seeing the error:
TASK [geerlingguy.mysql : Check slave replication status.] *****************************************************************************
fatal: [a4d-lamp-db-1]: FAILED! => {"changed": false, "msg": "unable to connect to database, check login_user and login_password are correct or /root/.my.cnf has the credentials. Exception message: (1045, "Access denied for user 'replication'@'localhost' (using password: YES)")"}

My next task is to deep dive into your mysql role and further troubleshoot this error. However, any help from someone who is much better versed than I with this code would be much appreciated. Could you please let me know if you have seen similar replication access denied errors in the past and if there are any specific fixes or places I should check in your LAMP example to resolve this master/slave replication problem?